### PR TITLE
Add a simple test item runner

### DIFF
--- a/LSpec.lean
+++ b/LSpec.lean
@@ -1,2 +1,3 @@
 import LSpec.Spec
 import LSpec.Meta
+import LSpec.Runner

--- a/LSpec/Runner.lean
+++ b/LSpec/Runner.lean
@@ -1,0 +1,82 @@
+import LSpec.Spec
+import LSpec.Meta
+import Init.Data.List.Basic
+import LSpec.Util.WriterT
+import LSpec.Util.Tree
+
+/-
+Structure for a test item in a test suite. Contains everything needed to run a test.
+We need to store the type of the specification target and the target
+itself because the specification depends on them.
+-/
+structure Item where
+  -- The type of the target of the specification
+  α : Type
+  -- The specification target
+  s : α
+  -- The specification
+  spec : SpecOn s
+  -- An runnable example for the specification
+  examp : ExampleOf spec
+
+/-
+A tree of test items. Each node has a description.
+This tree is used to define test suites.
+-/
+def SpecTree := Tree String Item
+-- A monad for constructing test suites.
+def SpecM := Writer (List SpecTree)
+  deriving Monad
+def Spec := SpecM Unit
+
+/-
+Adds a test item to the test suite.
+-/
+def it {α : Type} {a : α} (spec : SpecOn a) (t : ExampleOf spec) : SpecM Unit :=
+  let item : Item := ⟨α, a, spec, t⟩
+  tell [Tree.leaf item]
+
+/-
+Like `it`, but takes the spec as an implicit argument. Useful for
+when the example syntax from Meta.lean is used. That gives us
+an `ExampleOf` from which `spec` can be inferred.
+-/
+def it' {α : Type} {a : α} {spec : SpecOn a} (t : ExampleOf spec) : SpecM Unit := it spec t
+
+/-
+Combines a list of test items (represented with `SpecM` monad) into a single branch.
+-/
+def describe {α : Type u} (s : String) (m : SpecM α) : SpecM α := do
+  tell [Tree.node s m.run]
+  pure m.fst
+
+/-
+Indents a string by prepending it with spaces.
+-/
+def indentString (n : Nat) (s : String) : String :=
+  ⟨List.replicate n ' '⟩ ++ s
+
+/-
+A collection of pretty printing functions for the test tree.
+We're printing each test item separately instead of constructing
+a string for the entire tree because certain test items can
+potentially run for a long time.
+-/
+def printLeaf (indent : Nat) (i : Item) :=
+  IO.println ∘ indentString (indent*2) $
+    let ⟨descr, res, str⟩ := i.examp.run
+    match descr with
+    | .none => str
+    | .some descr => descr ++ ": " ++ str
+
+def printNode (indent : Nat) (t : String) := IO.println ∘ indentString (indent*2) $ t
+
+def printTree (t : SpecTree) : IO Unit := traverseTree 0 printLeaf printNode t
+
+/-
+Runs a test spec, printing the results.
+-/
+def Spec.run (spec : Spec) : IO Unit :=
+  let forest := Writer.run spec
+  for t in forest do
+    printTree t

--- a/LSpec/Util/Tree.lean
+++ b/LSpec/Util/Tree.lean
@@ -1,0 +1,22 @@
+/-
+A simple tree data structure where both leaves and internal nodes have some
+data attached.
+-/
+inductive Tree (τ : Type u) (α : Type v) where
+  -- A tree leaf, contains α
+  | leaf : α → Tree τ α
+  -- A tree node. Contains τ and a list of children.
+  | node : τ → List (Tree τ α) → Tree τ α
+  deriving Repr
+
+/-
+A function that traverses a tree. Takes two functions: one that is
+applied on leaves and another one that is applied on nodes.
+-/
+def traverseTree {α : Type u} {τ : Type v} [Monad m] (n : Nat) (leafF : Nat → α → m Unit) (nodeF : Nat → τ → m β) : Tree τ α → m Unit
+  | .leaf x => leafF n x
+  | .node t xs => do
+    let b ← nodeF n t
+    for x in xs do
+      traverseTree (n+1) leafF nodeF x
+decreasing_by sorry -- FIXME: Lean is not convinced that this function terminates and I couldn't prove it, so here's this stub for now.

--- a/LSpec/Util/WriterT.lean
+++ b/LSpec/Util/WriterT.lean
@@ -1,0 +1,60 @@
+/-
+A very simple Writer monad as Lean standard library doesn't have one.
+-/
+def Writer (ε : Type u) (α : Type w) := α × ε
+
+
+-- Append and EmptyCollection instead of Monoid because there's
+-- no Monoid type class in the standard library.
+instance [Append ε] [EmptyCollection ε] : Monad (Writer ε) where
+  pure x := ⟨ x, EmptyCollection.emptyCollection ⟩
+  bind x f :=
+    let (a, e1) := x
+    let (b, e2) := f a
+    (b, e1 ++ e2)
+
+/-
+Write a value to the Writer monad.
+-/
+def tell {ε : Type u} (e : ε) : Writer ε PUnit :=
+  ⟨PUnit.unit, e⟩
+
+/-
+Run a Writer action and return the result plus the output of the Writer.
+-/
+def listen {ε : Type u} {α : Type v} (x : Writer ε α) : Writer ε (α × ε) :=
+  let (a, e) := x
+  ((a, e), e)
+
+/-
+Run a Writer action and return the written output.
+-/
+def Writer.run {ε : Type u} {α : Type v} (x : Writer ε α) : ε := x.snd
+
+/-
+structure WriterT (ε : Type u) (m : Type u → Type v) (α : Type u) : Type (max u v) where
+  run: m (α × ε)
+
+def listen {ε : Type u} {m : Type u → Type v} [Monad.{u, v} m] [EmptyCollection.{u} ε] {α : Type u} (f : WriterT.{u,v} ε m α) : WriterT ε m (a × ε) := sorry
+
+instance [Monad m] : Functor (WriterT ε m) where
+  map f x := ⟨do
+    let (a, e) ← x.run
+    pure (f a, e) ⟩
+
+instance [Append ε] [EmptyCollection ε] [Monad m] : Monad (WriterT ε m) where
+  pure x := ⟨pure ⟨x, EmptyCollection.emptyCollection⟩⟩
+  bind x f := ⟨do
+    let (a, e1) ← x.run
+    have go := f a -- if I change this 'have' to 'let' it asks me to implement map for the instance. I don't know why.
+    let (b, e2) ← go.run
+    pure ⟨b, e2⟩
+  ⟩
+
+instance [EmptyCollection ε] [Monad m] : MonadLiftT m (WriterT ε m) where
+  monadLift m := ⟨do
+    let v ← m
+    pure ⟨v, EmptyCollection.emptyCollection⟩⟩
+
+def tell [Monad m] (e : ε) : WriterT ε m Unit := ⟨pure ⟨(), e⟩⟩
+-/

--- a/Tests/test.lean
+++ b/Tests/test.lean
@@ -1,4 +1,5 @@
 import LSpec.Meta
+import LSpec.Runner
 
 namespace test1
 
@@ -79,3 +80,47 @@ mkspec noOddSpec : onlyEven := depDoesntContain onlyEven
 #spec Tests noOddSpec with [([1,2,3],3), ([6,27,19,20],7), ([45,7,45,672,34,231,42,3],3)]
 
 end test3
+
+namespace test4
+
+-- Tests using raw functions
+def testTree : Spec :=
+  describe "test" do
+    it (doesntContain [1,2,3]) $ ExampleOf.fromDescrParam "[1,2,3] doesn't contain 4" 4
+    it (doesntContain [1,2,3]) $ ExampleOf.fromDescrParam "[1,2,3] doesn't contain 5" 5
+    describe "testing failures" $ do
+      it (doesntContain [1,2,3]) $ ExampleOf.fromDescrParam "[1,2,3] doesn't contain 1" 1
+      it (doesntContain [1,2,3]) $ ExampleOf.fromDescrParam "[1,2,3] doesn't contain 2" 2
+    it (equals 1 2) $ ExampleOf.fromDescrParam "1 equals 2" ()
+    it (equals 1 1) $ ExampleOf.fromDescrParam "1 equals 1" ()
+
+-- Tests that use the Meta.lean syntax
+def testTree2 : Spec :=
+  describe "test2" do
+     it' $ Test doesntContain [1,2,3] with 4 => "Hello"
+     it' $ Test doesntContain [1,2,3] with 3 => "World"
+     it' $ Test doesntContain [1,2,3] with 1
+
+-- testTree1 and testTree2 combined into a single tree
+def combined : Spec := do
+  describe "combined" do
+    testTree
+    testTree2
+
+#eval combined.run
+/-
+combined
+  test
+    [1,2,3] doesn't contain 4: ✓ Success!
+    [1,2,3] doesn't contain 5: ✓ Success!
+    testing failures
+      [1,2,3] doesn't contain 1: × Failure!
+      [1,2,3] doesn't contain 2: × Failure!
+    1 equals 2: × Failure!
+    1 equals 1: ✓ Success!
+  test2
+    Hello: ✓ Success!
+    World: × Failure!
+    × Failure!
+-/
+end test4


### PR DESCRIPTION
This PR adds the ability co construct and run test items monadically just like one would in `HSpec`.

There are some rough corners.
Firstly, the underlying tree structure uses a list for children nodes which confuses termination checker if one is trying to write any function that traverses such a tree. I did not manage to prove that my tree traversal function terminates (and maybe I'm wrong and it doesn't terminate somehow?), so I've put a `sorry` stub in there.

Secondly, ideally, the underlying monad should be `WriterT` so it can be extended with other things (like `Reader` can be helpful to provide an environment for certain tests). Unfortunately, this proved to be difficult mainly because I wanted the writer environment and the writer return value to be able to have different `Type` universes (since `Item` is `Type 1`) but we want to work with `Type 0` types in a monad too. Perhaps I'm missing something, but I could not make that work, I've left my attempts commented. I can remove them if needed. 