### PR TITLE
Update the Lean version, along with Lake syntax.

### DIFF
--- a/LSpec/LSpec.lean
+++ b/LSpec/LSpec.lean
@@ -74,7 +74,7 @@ This function is meant to be called from a custom command. It runs in
 def LSpec.runInTermElabMAsUnit (t : LSpec) : TermElabM Unit := do
   let (success?, msg) := t.runAndCompile
   if success? then
-    logInfo msg
+    Lean.logInfo msg
   else
     throwError msg
 

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -1,6 +1,7 @@
 import Lake
 open Lake DSL
 
-package LSpec {
-  binName := "lspec"
+package LSpec
+
+lean_exe lspec {
 }

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2022-05-29
+leanprover/lean4:nightly-2022-06-19


### PR DESCRIPTION
Newer Lake uses this lean_exe style syntax, and warns
for the older way.