### PR TITLE
Problem: can't run tests with compiled sources.

### DIFF
--- a/LSpec/Control/Random.lean
+++ b/LSpec/Control/Random.lean
@@ -32,7 +32,7 @@ defining objects that can be created randomly.
 abbrev RandT (g : Type) := StateM (ULift g)
 
 instance inhabitedRandT [Inhabited g] [Inhabited α] : Inhabited (RandT g α) where 
-  default := fun x => pure (default, .up default)
+  default := fun _ => pure (default, .up default)
 
 /-- A monad to generate random objects using the generator type `Rng` -/
 abbrev Rand (α : Type u) := RandT StdGen α

--- a/LSpec/Testing.lean
+++ b/LSpec/Testing.lean
@@ -8,21 +8,21 @@ import LSpec
   test "list nonempty" ¬ [42].isEmpty
 
 #lspec
-  test' "Nat equality" (4 = 4) $
-  test' "Nat inequality" (4 ≠ 5) $
-  test' "bool equality" (42 == 42) $
-  test' "list length" ([42].length = 1) $
-  test' "list nonempty" ¬ [42].isEmpty
+  test "Nat equality" (4 = 4) $
+  test "Nat inequality" (4 ≠ 5) $
+  test "bool equality" (42 == 42) $
+  test "list length" ([42].length = 1) $
+  test "list nonempty" ¬ [42].isEmpty
 
 /--
 Testing using `#lspec` with something of type `LSpec`.
 -/
-private def test1 : LSpec := do
-  test "Nat equality" <| 4 = 4
-  test "Nat inequality" <| 4 ≠ 5
-  test "bool equality" <| 42 == 42
-  test "list length" <| [42].length = 1
-  test "list nonempty" <| ¬ [42].isEmpty
+def test1 : LSpec := do
+  test "Nat equality" (4 = 4)
+  test "Nat inequality" (4 ≠ 5)
+  test "bool equality" (42 == 42)
+  test "list length" ([42].length = 1)
+  test "list nonempty" ¬ [42].isEmpty
 
 #lspec test1
 
@@ -31,7 +31,7 @@ private def test1 : LSpec := do
 /--
 Testing using `#lspec` with something of type `LSpecTest`.
 -/
-private def test2 := test "true" true
+def test2 := test "true" true
 
 #lspec test2
 
@@ -65,7 +65,7 @@ def fiveIO : IO Nat :=
 def main : IO UInt32 := do
   let four ← fourIO
   let five ← fiveIO
-  lspec do
+  lspecIO do
     test "fourIO equals 4" (four = 4)
     test "fiveIO equals 5" (five = 5)
 

--- a/Main.lean
+++ b/Main.lean
@@ -24,19 +24,17 @@ def runCmd (descr cmd : String) (args : Array String := #[]) : IO Bool := do
     IO.eprintln out.stderr
     return true
 
-def main (dirs : List String) : IO UInt32 := do
+def main : IO UInt32 := do
   if ← runCmd s!"Building project" "lake" #["build"] then
     return 1
   let mut exeFiles : List String := []
-  let dirs := dirs.map fun d => d.splitOn "." |>.head!
-  for dir in dirs do
-    for testCase in (← getFilePaths ⟨dir⟩).map
-        fun fp => (fp.toString.splitOn ".").head! do
-      let exe := testCase.replace "/" "-"
-      let pkg := testCase.replace "/" "."
-      if ← runCmd s!"Building {exe}" "lake" #["build", pkg] then
-        return (1 : UInt32)
-      exeFiles := exe :: exeFiles
+  for testCase in (← getFilePaths ⟨"Tests"⟩).map
+      fun fp => (fp.toString.splitOn ".").head! do
+    let exe := testCase.replace "/" "-"
+    let pkg := testCase.replace "/" "."
+    if ← runCmd s!"Building {exe}" "lake" #["build", pkg] then
+      return (1 : UInt32)
+    exeFiles := exe :: exeFiles
   let mut hasFailure : Bool := false
   for exe in exeFiles.reverse do
     hasFailure := hasFailure ||

--- a/Main.lean
+++ b/Main.lean
@@ -1,59 +1,48 @@
-import LSpec -- forcing oleans generation
+open System
 
-open System in
-partial def getFilePaths
-  (fp : FilePath) (ext : String) (acc : List FilePath := []) :
+partial def getFilePaths (fp : FilePath) (acc : List FilePath := []) :
     IO (List FilePath) := do
   if ← fp.isDir then
     let mut extra : List FilePath := []
     for dirEntry in (← fp.readDir) do
-      for innerFp in ← getFilePaths dirEntry.path ext do
+      for innerFp in ← getFilePaths dirEntry.path do
         extra := extra.concat innerFp
     return acc ++ extra
   else
-    if (fp.extension.getD "") == ext then
+    if (fp.extension.getD "") == "lean" then
       return acc.concat fp
     else
       return acc
 
-def runCmd (descr cmd : String)
-  (args : Array String := #[]) (env: Array (String × Option String) := #[]) :
-    IO Bool := do
+def runCmd (descr cmd : String) (args : Array String := #[]) : IO Bool := do
   IO.println descr
-  let out ← IO.Process.output { cmd := cmd, args := args, env := env }
-  if out.exitCode != 0 then
-    IO.println  out.stdout
+  let out ← IO.Process.output { cmd := cmd, args := args }
+  if out.exitCode == 0 then
+    IO.println out.stdout
+    return false
+  else
     IO.eprintln out.stderr
     return true
-  return false
 
-def main : IO UInt32 := do
-  if ← runCmd "Building main package" "lake" #["build"] then return 1
-
-  let mut testCases : List String := []
-
-  for testFilePath in ← getFilePaths ⟨"Tests"⟩ "lean" do
-    let testCase := testFilePath.fileName.get!
-    testCases := testCases.concat testCase
-
-  if testCases.isEmpty then
-    IO.println "\nNo more tests to run"
+def main (dirs : List String) : IO UInt32 := do
+  if ← runCmd s!"Building project" "lake" #["build"] then
+    return 1
+  let mut exeFiles : List String := []
+  let dirs := dirs.map fun d => d.splitOn "." |>.head!
+  for dir in dirs do
+    for testCase in (← getFilePaths ⟨dir⟩).map
+        fun fp => (fp.toString.splitOn ".").head! do
+      let exe := testCase.replace "/" "-"
+      let pkg := testCase.replace "/" "."
+      if ← runCmd s!"Building {exe}" "lake" #["build", pkg] then
+        return (1 : UInt32)
+      exeFiles := exe :: exeFiles
+  let mut hasFailure : Bool := false
+  for exe in exeFiles.reverse do
+    hasFailure := hasFailure ||
+      (← runCmd s!"Running {exe}" s!"./build/bin/{exe}")
+  if !hasFailure then
+    IO.println "All tests passed!"
     return 0
-
-  let mut allPassed : Bool := true
-
-  for testCase in testCases do
-    IO.println s!"\nRunning tests for {testCase}"
-    let out ← IO.Process.output {
-      cmd := "lake"
-      args := #["env", "lean", "--run", s!"Tests/{testCase}"]
-    }
-    IO.print out.stdout
-    if out.exitCode != 0 then
-      IO.eprint out.stderr
-      allPassed := false
-  
-  if allPassed then
-    IO.println "\nAll tests passed!"
-    return 0
+  IO.println "Some test failed!"
   return 1

--- a/README.md
+++ b/README.md
@@ -4,29 +4,25 @@ A testing framework for Lean 4, inspired by Haskell's [Hspec](https://hspec.gith
 
 ## Usage
 
-There are two ways to use LSpec: via the `#lspec` command and the `lspec` function.
-Both become available once you `import LSpec`.
+### Composing tests
 
-Use the former when you want to test a function in the same file it is defined.
-If you use `LSpec` as a dependency, a test failure shall interrupt the execution of the `lake build` command and throw an error visible in the editor.
+Sequences of tests are represented by the `TestSeq` datatype.
+In order to instantiate terms of `TestSeq`, use the `test` helper function:
 
-The latter is for writing tests in a separate test file.
-Test files can be run independently with the `lspec` binary, as shown later.
+```lean
+#check
+  test "Nat equality" (4 = 4) $
+  test "Nat inequality" (4 ≠ 5)
+-- test "Nat equality" (4 = 4) (test "Nat inequality" (4 ≠ 5)) : TestSeq
+```
 
-### The `TestSeq` type
-
-`TestSeq` is used to represent sequences of tests.
-In order to instantiate terms of `TestSeq`, use one of the two following helper functions:
-
-* `test`: consumes a description and a proposition;
-* `test'`: consumes a description, a proposition and an (optional) extra `TestSeq`.
-Use it if you don't want to use `do` notation.
-
-The propositions above, however, must have their own instances of `TDecidable`.
+`test` consumes a description a proposition and a next test
+The proposition, however, must have its own instance of `TDecidable`.
 
 ### The `TDecidable` class
 
 `TDecidable` is how Lean is instructed to decide whether certain propositions are resolved as `true` or `false`.
+
 This is an example of a simple instance for decidability of equalities:
 
 ```lean
@@ -44,47 +40,53 @@ Such instances are automatically imported via `import LSpec`.
 
 The user is, of course, free to provide their own instances.
 
-### The `#lspec` command
+### Actually running the tests
+
+#### The `#lspec` command
 
 The `#lspec` command allows you to test interactively in a file.
-It requires one argument `t : TestSeq`.
 
 Examples:
 
 ```lean
-import LSpec
+#lspec
+  test "four equals four" (4 = 4) $
+  test "five equals five" (5 = 5)
+-- ✓ four equals four
+-- ✓ five equals five
 
 #lspec do
   test "four equals four" (4 = 4)
   test "five equals five" (5 = 5)
-
-#lspec
-  test' "four equals four" (4 = 4) $
-  test' "five equals five" (5 = 5)
+-- ✓ four equals four
+-- ✓ five equals five
 ```
 
-### The `lspec` function
+An important note is that a failing test will raise an error, interrupting the building process.
 
-The `lspec` function is for writing tests in a separate file and represents the result of one `LSpec` test suite.
-Similarly to the `#lspec` command, it requires an argument of type `TestSeq`.
+The fact that test execution happens in the `LSpec` monad allows the use of `do` notation, as seen above.
+So one can (ab)use the `do` notation run multiple tests without dollar signs.
+In such case, every call to `test` creates a `TestSeq` with a single test.
 
-For example, we can create a standalone `Tests.lean` file:
+#### The `lspec` function
+
+The `lspec` function can be used for generic purposes inside other functions.
+It returns a term of type `Except String String`, representing success or failure, with a message for each case.
+
 ```lean
-import LSpec
+def tests :=
+  test "four equals four" (4 = 4) $
+  test "five equals five" (5 = 5)
 
-def main := lspec $
-  test "four equals four" (4 = 4)
+def foo : IO Unit := do
+  match lspec tests with
+  | .ok    msg => IO.println msg
+  | .error msg => IO.eprintln msg
 ```
 
-If you run `Tests.lean`, the expected output should be:
-```lean
-✓ four equals four
-```
+#### The `lspecIO` function
 
-#### Running tests with IO
-
-We can use the `lspec` function to run tests with values that come from
-computations in `IO` like this:
+`lspecIO` is meant to be used in files to be compiled and integrated in a testing infrastructure, as shown soon.
 
 ```lean
 def fourIO : IO Nat :=
@@ -101,23 +103,24 @@ def main : IO UInt32 := do
     test "fiveIO equals 5" (five = 5)
 ```
 
-### The `lspec` binary
+## Setting up a testing infra
 
-Suppose you want to create multiple test files, each with a separate test suite.
-Create a folder called `Tests` in the root directory of your project and then:
+The LSpec package also provides a binary that runs test files automatically.
+The binary becomes available by running `lake build LSpec`, which will generate the file `./lean_packages/LSpec/build/bin/lspec`.
 
-1. Add Lean files similar to the `Tests.lean` example above.
-2. Compile the LSpec binary with `lake build LSpec`.
-3. Run the binary with `./lean_packages/LSpec/build/bin/lspec`.
+The `lspec` binary can take multiple arguments, each referencing a Lean file or a directory of Lean files.
+For each Lean file present in the arguments passed to the binary, there must exist a corresponding `lean_exe` in your `lakefile.lean`.
 
-The `lspec` binary triggers a `lake build` automatically, which takes care of interactive tests created with the `#lspec` command.
+For instance, suppose that you call `./.../lspec F1.lean Some/Path` and the directory `Some/Path` contains the files `F2.lean` and `F3.lean`.
+In this case, you need to add the following lines to your `lakefile.lean`:
 
-After building your package, the `lspec` binary searches for and recursively runs Lean files inside the `Tests` directory.
-It allows adding folders inside `Tests` to create a custom file structure.
+```lean
+lean_exe F1
+lean_exe Some.Path.F2
+lean_exe Some.Path.F3
+```
 
-For this to work, all of your Lean files used in the tests must be built when `lake build` is called.
-
-## Using LSpec on CI
+### Using LSpec on CI
 
 To integrate LSpec to GitHub workflows, create the file `.github/workflows/lspec.yml` with the content:
 

--- a/README.md
+++ b/README.md
@@ -108,16 +108,15 @@ def main : IO UInt32 := do
 The LSpec package also provides a binary that runs test files automatically.
 The binary becomes available by running `lake build LSpec`, which will generate the file `./lean_packages/LSpec/build/bin/lspec`.
 
-The `lspec` binary can take multiple arguments, each referencing a Lean file or a directory of Lean files.
-For each Lean file present in the arguments passed to the binary, there must exist a corresponding `lean_exe` in your `lakefile.lean`.
+The `lspec` binary recursively searches for Lean files inside a `Tests` directory.
+For each Lean file present `Tests`, there must exist a corresponding `lean_exe` in your `lakefile.lean`.
 
-For instance, suppose that you call `./.../lspec F1.lean Some/Path` and the directory `Some/Path` contains the files `F2.lean` and `F3.lean`.
+For instance, suppose that the directory `Tests` contains the files `Tests/F1.lean` and `Tests/Some/Dir/F2.lean`.
 In this case, you need to add the following lines to your `lakefile.lean`:
 
 ```lean
-lean_exe F1
-lean_exe Some.Path.F2
-lean_exe Some.Path.F3
+lean_exe Tests.F1
+lean_exe Tests.Some.Dir.F2
 ```
 
 ### Using LSpec on CI

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -1,6 +1,9 @@
 import Lake
 open Lake DSL
 
-package LSpec {
-  binName := "lspec"
+package LSpec
+
+@[defaultTarget]
+lean_exe lspec {
+  root := `Main
 }

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2022-05-29
+leanprover/lean4:nightly-2022-07-07

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2022-07-07
+leanprover/lean4:nightly-2022-07-10


### PR DESCRIPTION
The `lspec` binary was running test files as scripts, which caused some errors, despite being slower than compiled code.

### Solution: update Lean's toolchain and use an improved Lake.

We're updating the Lean toolchain to make use of the most recent Lake updates, which allow the declaration of multiple binary files to be built via the `lake build` command.

  There's also an upgrade in the API to provide two different functions:
  * `lspec` as a general means to run tests
  * `lspecIO` with the same role as the previous `lspec` function