### PR TITLE
A better feedback for the `lspec` binary

### DIFF
--- a/LSpec/Instances.lean
+++ b/LSpec/Instances.lean
@@ -1,25 +1,28 @@
 import LSpec.LSpec
 
-def formatBinaryError (m : String) (x y : α) [Repr α] : Std.Format :=
-  s!"{m}{(repr x).indentD}\nand{(repr y).indentD}"
-
-instance (x y : α) [DecidableEq α] [Repr α] : TDecidable (x = y) :=
+instance (priority := 50) (x y : α) [DecidableEq α] [Repr α] : TDecidable (x = y) :=
   if h : x = y then
     .isTrue h
   else
-    .isFalse h $ formatBinaryError "Expected to be equal:" x y
+    .isFalse h $ formatExpectedButGotMsg x y
 
-instance (x y : α) [BEq α] [Repr α] : TDecidable (x == y) :=
+instance (priority := 50) (x y : α) [BEq α] [Repr α] : TDecidable (x == y) :=
   if h : x == y then
     .isTrue h
   else
-    .isFalse h $ formatBinaryError "Expected to be equal:" x y
+    .isFalse h $ formatExpectedButGotMsg x y
 
-instance (x y : α) [DecidableEq α] [Repr α] : TDecidable (x ≠ y) :=
+instance (priority := 50) (x y : α) [DecidableEq α] [Repr α] : TDecidable (x ≠ y) :=
   if h : x ≠ y then
     .isTrue h
   else
-    .isFalse h s!"Both equal to:{(repr x).indentD}"
+    .isFalse h s!"Expected to be different but both equal to '{repr x}'"
+
+instance (priority := 50) (x y : α) [BEq α] [Repr α] : TDecidable (x != y) :=
+  if h : x != y then
+    .isTrue h
+  else
+    .isFalse h s!"Expected to be different but both equal to '{repr x}'"
 
 /--
 A fancier example of `TDecidable` instance that allows us to write:

--- a/LSpec/LSpec.lean
+++ b/LSpec/LSpec.lean
@@ -97,6 +97,19 @@ def lspec (t : TestSeq) : IO UInt32 := do
   if ← t.runIO then return 0
   return 1
 
+/--
+Runs a sequence of tests that are created from a `List α` and a function
+`α → IO TestSeq`. Instead of creating all tests and running them consecutively,
+this function alternates between test creation and test execution.
+
+It's rather useful for when the test creation process involves heavy
+computations in `IO` (e.g. when `f` reads data from files and processes it).
+-/
+def lspecEachWith (l : List α) (f : α → IO TestSeq) : IO UInt32 := do
+  let success ← l.foldlM (init := true) fun acc a => do
+    pure $ acc && (← ( ← f a).runIO)
+  return if success then 0 else 1
+
 inductive ExpectationFailure (exp got : String) : Prop
 
 def formatExpectedButGotMsg [Repr α] (exp got : α) : String :=

--- a/LSpec/LSpec.lean
+++ b/LSpec/LSpec.lean
@@ -6,13 +6,13 @@ explanatory message.
 -/
 class inductive TDecidable (p : Prop) where
   | isTrue  (h : p)
-  | isFalse (h : ¬ p) (msg : Option Std.Format := none)
-  | isFailure (msg : Option Std.Format := none)
+  | isFalse (h : ¬ p) (msg : Option String := none)
+  | isFailure (msg : Option String := none)
 
 /-- A default `TDecidable` instance with low priority. -/
-instance (priority := low) (p : Prop) [d : Decidable p] : TDecidable p :=
+instance (priority := 25) (p : Prop) [d : Decidable p] : TDecidable p :=
   match d with
-  | isFalse h => .isFalse h f!"Evaluated to false"
+  | isFalse h => .isFalse h "Evaluated to false"
   | isTrue  h => .isTrue  h
 
 /-- The datatype used to represent a sequence of tests. -/
@@ -33,61 +33,44 @@ def test (descr : String) (p : Prop) [TDecidable p]
     (next : TestSeq := .done) : TestSeq :=
   .more descr p inferInstance next
 
-abbrev LSpecResult := String × Bool × Option Std.Format
+/-- Formats the extra error message from `TDecidable` failures. -/
+def formatErrorMsg : Option String → String
+  | some msg => s!"\n    {msg}"
+  | none     => ""
 
-/-- `LSpec` is the monad used to run tests and record their results. -/
-abbrev LSpec := StateT (List LSpecResult) Id Unit
+/-- A generic runner for `TestSeq` -/
+def TestSeq.run (tSeq : TestSeq) : Bool × String :=
+  let rec aux (acc : String) : TestSeq → Bool × String
+    | .done => (true, acc)
+    | .more d _ (.isTrue _) n =>
+      let (b, m) := aux s!"{acc}✓ {d}\n" n
+      (true && b, m)
+    | .more d _ (.isFalse _ msg) n
+    | .more d _ (.isFailure msg) n =>
+      let (b, m) := aux s!"{acc}× {d}{formatErrorMsg msg}\n" n
+      (false && b, m)
+  aux "" tSeq
 
-/-- Runs a sequence of test in the `LSpec` monad -/
-def TestSeq.toLSpec : TestSeq → LSpec
-  | .more d _ (.isTrue _) n    => do set ((d, true, none) :: (← get)); n.toLSpec
-  | .more d _ (.isFalse _ m) n => do set ((d, false, m) :: (← get));   n.toLSpec
-  | .more d _ (.isFailure m) n => do set ((d, false, m) :: (← get));   n.toLSpec
-  | .done                      => pure ()
-
-instance : Coe TestSeq LSpec where
-  coe := TestSeq.toLSpec
-
-/--
-Runs a set of `LSpec` tests and appends the results to another list of results
-(given as input by the caller).
--/
-def LSpec.run (tests : LSpec) : List LSpecResult :=
-  (StateT.run tests []).2.reverse
-
-/-- Formats the result of a test for printing. -/
-def formatLSpecResult : LSpecResult → String
-  | (d, b, msg) =>
-    let head := if b then s!"✓ {d}" else s!"× {d}"
-    match msg with
-    | some m => head ++ m.indentD.pretty
-    | none   => head
-
-/--
-Generates a report for all the results in a `LSpec` test, returning `true` if
-all tests passed and `false` otherwise.
--/
-def LSpec.runAndCompile (t : LSpec) : Bool × String :=
-  let res := t.run
-  (res.foldl (init := true) fun acc (_, r, _) => acc && r,
-    "\n".intercalate <| res.map formatLSpecResult)
-
-/-- Runs a `LSpec` for generic purposes. -/
-def lspec (t : LSpec) : Except String String :=
-  match t.runAndCompile with
-  | (true,  msg) => return msg
-  | (false, msg) => throw msg
+/-- A runner for `IO` that prints test outputs instead of storing them. -/
+def TestSeq.runIO : TestSeq → IO Bool
+  | .done => pure true
+  | .more d _ (.isTrue _) n => do
+    IO.println s!"✓ {d}"
+    return true && (← n.runIO)
+  | .more d _ (.isFalse _ msg) n
+  | .more d _ (.isFailure msg) n => do
+    IO.println s!"× {d}{formatErrorMsg msg}"
+    return false && (← n.runIO)
 
 /--
-Runs a `LSpec` with an output meant for the Lean Infoview.
-
+Runs a `TestSeq` with an output meant for the Lean Infoview.
 This function is meant to be called from a custom command. It runs in
 `TermElabM` to have access to `logInfo` and `throwError`.
 -/
-def LSpec.runInTermElabMAsUnit (t : LSpec) : Lean.Elab.TermElabM Unit :=
-  match lspec t with
-  | .ok    msg => Lean.logInfo msg
-  | .error msg => throwError msg
+def LSpec.runInTermElabMAsUnit (tSeq : TestSeq) : Lean.Elab.TermElabM Unit :=
+  match tSeq.run with
+  | (true,  msg) => Lean.logInfo msg
+  | (false, msg) => throwError msg
 
 /--
 A custom command to run `LSpec` tests. Example:
@@ -97,10 +80,10 @@ A custom command to run `LSpec` tests. Example:
 ```
 -/
 macro "#lspec " term:term : command =>
-  `(#eval (LSpec.runInTermElabMAsUnit $term:term))
+  `(#eval LSpec.runInTermElabMAsUnit $term)
 
 /--
-Runs a `LSpec` with an output meant for the terminal.
+Runs a `TestSeq` with an output meant for the terminal.
 
 This function is designed to be plugged to a `main` function from a Lean file
 that can be compiled. Example:
@@ -110,15 +93,17 @@ def main := lspecIO $
   test "four equals four" (4 = 4)
 ```
 -/
-def lspecIO (t : LSpec) : IO UInt32 := do
-  match lspec t with
-  | .ok    msg => IO.println  msg; return 0
-  | .error msg => IO.eprintln msg; return 1
+def lspec (t : TestSeq) : IO UInt32 := do
+  if ← t.runIO then return 0
+  return 1
 
 inductive ExpectationFailure (exp got : String) : Prop
 
+def formatExpectedButGotMsg [Repr α] (exp got : α) : String :=
+  s!"Expected '{repr exp}' but got '{repr got}'"
+
 instance : TDecidable (ExpectationFailure exp got) :=
-  .isFailure s!"Expected '{exp}' but got '{got}'"
+  .isFailure $ formatExpectedButGotMsg exp got
 
 /-- A test pipeline to run a function assuming that `opt` is `Option.some _` -/
 def withOptionSome (descr : String) (opt : Option α) (f : α → TestSeq) :

--- a/LSpec/Testing.lean
+++ b/LSpec/Testing.lean
@@ -1,14 +1,7 @@
 import LSpec
 
-#lspec do
-  test "Nat equality" (4 = 4)
-  test "Nat inequality" (4 ≠ 5)
-  test "bool equality" (42 == 42)
-  test "list length" ([42].length = 1)
-  test "list nonempty" ¬ [42].isEmpty
-
 #lspec
-  test "Nat equality" (4 = 4) $
+  test "Nat equality" (4 = 5) $
   test "Nat inequality" (4 ≠ 5) $
   test "bool equality" (42 == 42) $
   test "list length" ([42].length = 1) $
@@ -17,11 +10,11 @@ import LSpec
 /--
 Testing using `#lspec` with something of type `LSpec`.
 -/
-def test1 : LSpec := do
-  test "Nat equality" (4 = 4)
-  test "Nat inequality" (4 ≠ 5)
-  test "bool equality" (42 == 42)
-  test "list length" ([42].length = 1)
+def test1 : TestSeq :=
+  test "Nat equality" (4 = 4) $
+  test "Nat inequality" (4 ≠ 5) $
+  test "bool equality" (42 == 42) $
+  test "list length" ([42].length = 1) $
   test "list nonempty" ¬ [42].isEmpty
 
 #lspec test1
@@ -37,9 +30,9 @@ def test2 := test "true" true
 
 #lspec test "true" <| true
 
-#lspec do
-  test "a" <| 4 = 4
-  test "b" <| 4 ≠ 5
+#lspec
+  test "a" (4 = 4) $
+  test "b" (4 ≠ 5)
 
 #lspec
   test "array eq" <| #[1,2,3] = (List.range 3).toArray
@@ -65,8 +58,8 @@ def fiveIO : IO Nat :=
 def main : IO UInt32 := do
   let four ← fourIO
   let five ← fiveIO
-  lspecIO do
-    test "fourIO equals 4" (four = 4)
+  lspec $
+    test "fourIO equals 4" (four = 4) $
     test "fiveIO equals 5" (five = 5)
 
 #eval main

--- a/README.md
+++ b/README.md
@@ -54,39 +54,13 @@ Examples:
   test "five equals five" (5 = 5)
 -- ✓ four equals four
 -- ✓ five equals five
-
-#lspec do
-  test "four equals four" (4 = 4)
-  test "five equals five" (5 = 5)
--- ✓ four equals four
--- ✓ five equals five
 ```
 
 An important note is that a failing test will raise an error, interrupting the building process.
 
-The fact that test execution happens in the `LSpec` monad allows the use of `do` notation, as seen above.
-So one can (ab)use the `do` notation run multiple tests without dollar signs.
-In such case, every call to `test` creates a `TestSeq` with a single test.
-
 #### The `lspec` function
 
-The `lspec` function can be used for generic purposes inside other functions.
-It returns a term of type `Except String String`, representing success or failure, with a message for each case.
-
-```lean
-def tests :=
-  test "four equals four" (4 = 4) $
-  test "five equals five" (5 = 5)
-
-def foo : IO Unit := do
-  match lspec tests with
-  | .ok    msg => IO.println msg
-  | .error msg => IO.eprintln msg
-```
-
-#### The `lspecIO` function
-
-`lspecIO` is meant to be used in files to be compiled and integrated in a testing infrastructure, as shown soon.
+`lspec` is meant to be used in files to be compiled and integrated in a testing infrastructure, as shown soon.
 
 ```lean
 def fourIO : IO Nat :=


### PR DESCRIPTION
* The binary now prints test outputs as they're produced
* No more build logs spam in cases of successful builds
* Simplified methods to run tests; no more monadic coercions nor do notation magic

Closes #25 