### PR TITLE
Fix path replace for windows OS

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -28,7 +28,7 @@ def runCmd (descr cmd : String) (args : Array String := #[])
 def getDefaultLeanPaths : IO $ List (String × String) :=
   return (← getLeanFilePathsList ⟨"Tests"⟩).data.map fun fp =>
     let path := (fp.toString.splitOn ".").head!
-    (path.replace "/" ".", path.replace "/" "-")
+    (path.replace System.FilePath.pathSeparator.toString ".", path.replace System.FilePath.pathSeparator.toString "-")
 
 def getUserLeanPaths (args : List String) : List (String × String) :=
   args.map fun path =>

--- a/Main.lean
+++ b/Main.lean
@@ -28,7 +28,8 @@ def runCmd (descr cmd : String) (args : Array String := #[])
 def getDefaultLeanPaths : IO $ List (String × String) :=
   return (← getLeanFilePathsList ⟨"Tests"⟩).data.map fun fp =>
     let path := (fp.toString.splitOn ".").head!
-    (path.replace System.FilePath.pathSeparator.toString ".", path.replace System.FilePath.pathSeparator.toString "-")
+    let sep := System.FilePath.pathSeparator.toString
+    (path.replace sep ".", path.replace sep "-")
 
 def getUserLeanPaths (args : List String) : List (String × String) :=
   args.map fun path =>


### PR DESCRIPTION
On `windows` OS `lake exe lspec` command fail with error: unknown target `Tests\Testing`

```
C:\lean\github\Sample>lake exe lspec
Building Tests\Testing
error: unknown target `Tests\Testing`

Failed to build Tests\Testing.

C:\lean\github\Sample>
``` 

This is fixed by this PR that use OS file path separator.

Thanks