### PR TITLE
Add support for test groups

### DIFF
--- a/LSpec/Testing.lean
+++ b/LSpec/Testing.lean
@@ -1,6 +1,6 @@
 import LSpec
 
-open LSpec 
+open LSpec
 
 #lspec
   test "Nat equality" (4 = 5) $
@@ -14,6 +14,20 @@ open LSpec
 -- ✓ bool equality
 -- ✓ list length
 -- ✓ list nonempty
+
+-- Testing a test group. Indents are important!
+def tGroup : TestSeq := group "test group test" $
+  test "Nat inequality" (4 ≠ 5) $
+  test "Nat inequality" (3 ≠ 5) $
+  test "Nat equality" (42 == 42)
+
+#lspec (tGroup ++ tGroup ++ test "Nat equality" (42 = 42))
+#lspec (
+  test "Nat equality" (42 = 42) $
+  group "manual group" (
+    test "Nat equality inside group" (4 = 4)) $
+  tGroup
+  )
 
 /--
 Testing using `#lspec` with something of type `LSpec`.
@@ -77,8 +91,9 @@ def main := do
   let four ← fourIO
   let five ← fiveIO
   lspecIO $
+    tGroup ++ (
     test "fourIO equals 4" (four = 4) $
-    test "fiveIO equals 5" (five = 5)
+    test "fiveIO equals 5" (five = 5))
 
 #eval main
 -- ✓ fourIO equals 4

--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ In order to instantiate terms of `TestSeq`, use the `test` helper function:
 `test` consumes a description a proposition and a next test
 The proposition, however, must have its own instance of `Testable`.
 
+You can also collect `TestSeq` into conceptual test groups by using the
+helper function `group`:
+
+```lean
+#check
+  test "Nat equality" (42 = 42) $
+  group "manual group" $
+    test "Nat equality inside group" (4 = 4)
+```
+
 ### The `Testable` class
 
 `Testable` is how Lean is instructed to decide whether certain propositions are resolved as `true` or `false`.


### PR DESCRIPTION
Problem: LSpec is awesome, but when a codebase's test coverage is good (as it should be 🙈), individual tests quickly become a wall of text. Often in case of low-level tests that test polymorphic functions, the descriptions are all basically the same except for type names or some other minor details.

Solution: Haskell 'tasty' lib provides a test group concept, which is basically a list of tests with a description and nice formatting.
Though LSpec is in many ways simpler than tasty, it would be nice to steal this one construct.
Defined another constructor in the `TestSeq` inductive, consisting of a description `String` field, a `TestSeq` of tests in the group, and the optional 'next' sequence, same as before for individual tests.

Indentation (none for individual test sequences, two spaces for test groups by default) was added to `TestSeq.run` and `TestSeq.runM` functions to make test results print prettier.