### PR TITLE
Bump toolchain

### DIFF
--- a/CI.lean
+++ b/CI.lean
@@ -1,0 +1,33 @@
+open System
+
+def ciConfig (branches : String) : String := s!"name: \"LSpec CI\"
+on:
+  pull_request:
+  push:
+    branches:{branches}
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: install elan
+        run: |
+          set -o pipefail
+          curl -sSfL https://github.com/leanprover/elan/releases/download/v1.4.2/elan-x86_64-unknown-linux-gnu.tar.gz | tar xz
+          ./elan-init -y --default-toolchain none
+          echo \"$HOME/.elan/bin\" >> $GITHUB_PATH
+      - uses: actions/checkout@v2
+      - name: run LSpec binary
+        run: lake exe lspec
+"
+
+def main (branches : List String) : IO Unit := do
+  let branches := if branches.isEmpty then ["main"] else branches
+  let branches := .join $ branches.map (s!"\n      - {·}")
+  let wfPath : FilePath := ".github" / "workflows"
+  let ciPath : FilePath := wfPath / "lspec.yml"
+  if ← ciPath.pathExists then
+    IO.println s!"{ciPath} already exists"
+  else
+    if !(← wfPath.pathExists) then IO.FS.createDirAll wfPath
+    IO.FS.writeFile ciPath (ciConfig branches)

--- a/LSpec/LSpec.lean
+++ b/LSpec/LSpec.lean
@@ -101,7 +101,7 @@ def check (descr : String) (p : Prop)
 inductive ExpectationFailure (exp got : String) : Prop
 
 instance : Testable (ExpectationFailure exp got) :=
-  .isFailure s!"Expected {repr exp} but got {repr got}"
+  .isFailure s!"Expected '{repr exp}' but got '{repr got}'"
 
 /-- A test pipeline to run a function assuming that `opt` is `Option.some _` -/
 def withOptionSome (descr : String) (opt : Option α) (f : α → TestSeq) :

--- a/LSpec/LSpec.lean
+++ b/LSpec/LSpec.lean
@@ -101,7 +101,7 @@ def check (descr : String) (p : Prop)
 inductive ExpectationFailure (exp got : String) : Prop
 
 instance : Testable (ExpectationFailure exp got) :=
-  .isFailure s!"Expected '{repr exp}' but got '{repr got}'"
+  .isFailure s!"Expected {repr exp} but got {repr got}"
 
 /-- A test pipeline to run a function assuming that `opt` is `Option.some _` -/
 def withOptionSome (descr : String) (opt : Option α) (f : α → TestSeq) :
@@ -180,30 +180,30 @@ end PureTesting
 
 section MonadicTesting
 
-class MonadEmit (m) [Monad m] where
+class TestMonadEmit (m) [Monad m] where
   emit : String → m Unit
-
-export MonadEmit (emit)
+  fail : String → m Unit
 
 /-- A monadic runner that emits test outputs as they're produced. -/
-def TestSeq.runM (tSeq : TestSeq) (indent := 0)
-  [Monad m] [MonadEmit m] : m Bool :=
+def TestSeq.runM (tSeq : TestSeq) (indent := 0) [Monad m] [h : TestMonadEmit m] :
+    m Bool :=
   let pad := String.mk $ List.replicate indent ' '
   match tSeq with
   | .done => return true
   | .group d ts n => do
-    emit s!"{d}:"
+    h.emit s!"{d}:"
     let gb ← ts.runM (indent + 2)
     return gb && (← n.runM indent)
   | .individual d _ (.isTrue _) n => do
-    emit $ s!"{pad}✓ {d}"
+    h.emit s!"{pad}✓ {d}"
     return true && (← n.runM indent)
   | .individual d _ (.isMaybe msg) n => do
-    emit $ s!"{pad}? {d}{formatErrorMsg msg}"
+    h.emit s!"{pad}? {d}{formatErrorMsg msg}"
     return true && (← n.runM indent)
   | .individual d _ (.isFalse _ msg) n
   | .individual d _ (.isFailure msg) n => do
-    emit $ s!"{pad}× {d}{formatErrorMsg msg}"
+    let msg := s!"{pad}× {d}{formatErrorMsg msg}"
+    h.emit msg; h.fail msg -- also emitting messages from failed tests
     return false && (← n.runM indent)
 
 class MonadTest (m) [Monad m] (α) where
@@ -211,14 +211,14 @@ class MonadTest (m) [Monad m] (α) where
   failure : α
   nEq     : success ≠ failure
 
-def succeed [Monad m] [inst : MonadTest m α] : m α :=
-  return inst.success
+def succeed [Monad m] [h : MonadTest m α] : m α :=
+  return h.success
 
-def fail [Monad m] [inst : MonadTest m α] : m α :=
-  return inst.failure
+def fail [Monad m] [h : MonadTest m α] : m α :=
+  return h.failure
 
-/-- Runs a `TestSeq` in a monad with `MonadEmit` and `MonadTest`. -/
-def lspecM [Monad m] [MonadEmit m] [MonadTest m α] (t : TestSeq) : m α := do
+/-- Runs a `TestSeq` in a monad with `TestMonadEmit` and `MonadTest`. -/
+def lspecM [Monad m] [TestMonadEmit m] [MonadTest m α] (t : TestSeq) : m α := do
   if ← t.runM then succeed
   else fail
 
@@ -226,7 +226,7 @@ def lspecM [Monad m] [MonadEmit m] [MonadTest m α] (t : TestSeq) : m α := do
 Interspersedly creates a `TestSeq` from each element `β` of a list with a
 function `β → m TestSeq` and runs the test sequence.
 -/
-def lspecEachM [Monad m] [MonadEmit m] [MonadTest m α]
+def lspecEachM [Monad m] [TestMonadEmit m] [MonadTest m α]
     (l : List β) (f : β → m TestSeq) : m α := do
   let success ← l.foldlM (init := true) fun acc a => do
     pure $ acc && (← ( ← f a).runM)
@@ -234,8 +234,8 @@ def lspecEachM [Monad m] [MonadEmit m] [MonadTest m α]
 
 section IOTesting
 
-instance : MonadEmit IO :=
-  ⟨IO.println⟩
+instance : TestMonadEmit IO :=
+  ⟨IO.println, IO.eprintln⟩
 
 instance : MonadTest IO UInt32 :=
   ⟨0, 1, by decide⟩

--- a/Main.lean
+++ b/Main.lean
@@ -1,57 +1,49 @@
 open System
 
-partial def getLeanFilePathsList (fp : FilePath) (acc : Array FilePath := #[]) :
+partial def getLeanPaths (fp : FilePath) (acc : Array FilePath := #[]) :
     IO $ Array FilePath := do
   if ← fp.isDir then
-    let mut extra : Array FilePath := #[]
-    for dirEntry in ← fp.readDir do
-      for innerFp in ← getLeanFilePathsList dirEntry.path do
-        extra := extra.push innerFp
-    return acc.append extra
-  else
-    if (fp.extension.getD "") == "lean" then
-      return acc.push fp
-    else
-      return acc
+    (← fp.readDir).foldlM (fun acc dir => getLeanPaths dir.path acc) acc
+  else return if fp.extension == some "lean" then acc.push fp else acc
 
-def runCmd (descr cmd : String) (args : Array String := #[])
-    (building : Bool) : IO Bool := do
-  IO.println descr
-  if building then
-    let out ← IO.Process.output { cmd := cmd, args := args }
-    if out.exitCode == 0 then return false
-    else IO.eprintln out.stderr; return true
-  else
-    let out ← IO.Process.spawn { cmd := cmd, args := args }
-    return (← out.wait) != 0
+def runCmd (cmd : String) (args : Array String) (testing : Bool) :
+    IO $ Option String := do
+  let out ← IO.Process.output { cmd := cmd, args := args }
+  if testing then IO.println out.stdout
+  if out.exitCode == 0 then return none
+  else return some out.stderr
 
-def getDefaultLeanPaths : IO $ List (String × String) :=
-  return (← getLeanFilePathsList ⟨"Tests"⟩).data.map fun fp =>
-    let path := (fp.toString.splitOn ".").head!
+def getDefaultLeanPaths : IO $ Array (String × String) :=
+  return (← getLeanPaths ⟨"Tests"⟩).map fun path =>
+    let path := path.withExtension "" |>.toString
     let sep := System.FilePath.pathSeparator.toString
     (path.replace sep ".", path.replace sep "-")
 
-def getUserLeanPaths (args : List String) : List (String × String) :=
-  args.map fun path =>
+def getUserLeanPaths (args : List String) : Array (String × String) :=
+  .mk $ args.map fun path =>
     let lib := s!"Tests.{path}"
     (lib, lib.replace "." "-")
 
 def main (args : List String) : IO UInt32 := do
-  let mut exeFiles : List String := []
+  let mut exeFiles := #[]
   let leanPaths :=
     if args.isEmpty then ← getDefaultLeanPaths
     else getUserLeanPaths args
   for (lib, exe) in leanPaths do
-    if ← runCmd s!"Building {exe}" "lake" #["build", lib] true then
-      IO.eprintln s!"Failed to build {exe}."
+    IO.println s!"Building {exe}"
+    match ← runCmd "lake" #["build", lib] false with
+    | some msg =>
+      IO.eprintln s!"{msg}\nFailed to build {exe}"
       return 1
-    exeFiles := exe :: exeFiles
-  let mut hasFailure : Bool := false
-  for exe in exeFiles.reverse do
-    hasFailure := hasFailure ||
-      (← runCmd s!"\nRunning {exe}" s!"./build/bin/{exe}" #[] false)
-  if !hasFailure then
+    | none => exeFiles := exeFiles.push exe
+  let mut failures := #[]
+  for exe in exeFiles do
+    IO.println s!"\nRunning {exe}"
+    match ← runCmd s!"./build/bin/{exe}" #[] true with
+    | some msg => failures := failures.push msg
+    | none => pure ()
+  if failures.isEmpty then
     IO.println "\nAll tests passed!"
     return 0
-  IO.eprintln "\nSome test failed!"
+  IO.eprintln s!"\nFailed tests:\n{"\n".intercalate failures.data}"
   return 1

--- a/README.md
+++ b/README.md
@@ -140,9 +140,18 @@ lean_exe Tests.F1
 lean_exe Tests.Some.Dir.F2
 ```
 
+## Running specific test suites
+
+The `lspec` binary also accepts specific test suites as input.
+For example, you can call `lake exe lspec Foo Some.Bar` and it will build and run `Tests/Foo.lean` and `Tests/Some/Bar.lean`.
+
+This is particularly useful for running certain tests locally.
+
 ### Using LSpec on CI
 
-To integrate LSpec to GitHub workflows, create the file `.github/workflows/lspec.yml` with the content:
+To integrate LSpec to GitHub workflows, run `lake exe lspec-ci <branch list>`.
+The singleton `["main"]` is the default branch list.
+`lspec-ci` will create a file `.github/workflows/lspec.yml` with the content:
 
 ```yml
 name: "LSpec CI"
@@ -150,7 +159,9 @@ on:
   pull_request:
   push:
     branches:
-      - main
+      - <branch1>
+      - <branch2>
+      - ...
 jobs:
   build:
     name: Build
@@ -166,10 +177,3 @@ jobs:
       - name: run LSpec binary
         run: lake exe lspec
 ```
-
-## Running specific test suites
-
-The `lspec` binary also accepts specific test suites as input.
-For example, you can call `lake exe lspec Foo Some.Bar` and it will build and run `Tests/Foo.lean` and `Tests/Some/Bar.lean`.
-
-This is particularly useful for running certain tests locally.

--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ Examples:
 
 An important note is that a failing test will raise an error, interrupting the building process.
 
-#### The `lspec` function
+#### The `lspecIO` function
 
-`lspec` is meant to be used in files to be compiled and integrated in a testing infrastructure, as shown soon.
+`lspecIO` is meant to be used in files to be compiled and integrated in a testing infrastructure, as shown soon.
 
 ```lean
 def fourIO : IO Nat :=
@@ -129,10 +129,10 @@ Once this is done a `Slimcheck` test is evaluated in a similar way to
 The LSpec package also provides a binary that runs test files automatically.
 Run `lake exe lspec` to build it (if it hasn't been built yet) and execute it.
 
-The `lspec` binary recursively searches for Lean files inside a `Tests` directory.
-For each Lean file present `Tests`, there must exist a corresponding `lean_exe` in your `lakefile.lean`.
+The `lspec` binary searches for binary executables defined in `lakefile.lean` whose module name starts with "Tests".
+Then it builds and runs each of them.
 
-For instance, suppose that the directory `Tests` contains the files `Tests/F1.lean` and `Tests/Some/Dir/F2.lean`.
+For instance, suppose you want to run the test suites defined in `Tests/F1.lean` and `Tests/Some/Dir/F2.lean`.
 In this case, you need to add the following lines to your `lakefile.lean`:
 
 ```lean
@@ -143,14 +143,14 @@ lean_exe Tests.Some.Dir.F2
 ## Running specific test suites
 
 The `lspec` binary also accepts specific test suites as input.
-For example, you can call `lake exe lspec Foo Some.Bar` and it will build and run `Tests/Foo.lean` and `Tests/Some/Bar.lean`.
+For example, you can call `lake exe lspec Tests/Foo.lean Tests/Some/Bar.lean` and it will build and run those.
 
-This is particularly useful for running certain tests locally.
+This is particularly useful for running test suites locally.
 
 ### Using LSpec on CI
 
-To integrate LSpec to GitHub workflows, run `lake exe lspec-ci <branch list>`.
-The singleton `["main"]` is the default branch list.
+To integrate LSpec to GitHub workflows, run `lake exe lspec-ci branch1 branch2`.
+The singleton containing `main` is the default branch list.
 `lspec-ci` will create a file `.github/workflows/lspec.yml` with the content:
 
 ```yml

--- a/Tests/aa.lean
+++ b/Tests/aa.lean
@@ -1,4 +1,0 @@
-def main : IO UInt32 := do
-  IO.print "aa"
-  IO.eprint "bb"
-  return 1

--- a/Tests/aa.lean
+++ b/Tests/aa.lean
@@ -1,0 +1,4 @@
+def main : IO UInt32 := do
+  IO.print "aa"
+  IO.eprint "bb"
+  return 1

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -1,0 +1,1 @@
+{"version": 4, "packagesDir": "./lake-packages", "packages": []}

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -6,13 +6,9 @@ package LSpec
 lean_lib LSpec
 
 @[default_target]
-lean_exe lspec {
+lean_exe lspec where
   supportInterpreter := true
   root := `Main
-}
 
-lean_exe «lspec-ci» {
+lean_exe «lspec-ci» where
   root := `CI
-}
-
-lean_exe Tests.aa

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -7,7 +7,6 @@ lean_lib LSpec
 
 @[default_target]
 lean_exe lspec where
-  supportInterpreter := true
   root := `Main
 
 lean_exe «lspec-ci» where

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -7,5 +7,12 @@ lean_lib LSpec
 
 @[default_target]
 lean_exe lspec {
+  supportInterpreter := true
   root := `Main
 }
+
+lean_exe «lspec-ci» {
+  root := `CI
+}
+
+lean_exe Tests.aa

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2022-11-04
+leanprover/lean4:nightly-2022-12-23


### PR DESCRIPTION
* Bump toolchain to `leanprover/lean4:nightly-2022-12-23`
* Implement `lake-ci`, which can create a GitHub workflow file automatically
* Improve the search for default test suites. It no longer iterates on existing files in the `Tests` folder. Instead, it searches for executable binaries defined in `lakefile.lean`
* Present failed tests when the test run ends instead of just "some test failed"
* Change the input format for running specific test suites so that it accepts tab-completed paths
* Fix potential points of failure for Windows users by properly constructing file paths with OS-dependent path separators